### PR TITLE
Robust regex

### DIFF
--- a/erc-youtube.el
+++ b/erc-youtube.el
@@ -75,8 +75,8 @@ eyecatchup from Stackoverflow.com. Greetz and howdy.
 http://stackoverflow.com/a/10315969/28524
 http://stackoverflow.com/users/624466/eyecatchup")
 
-(defcustom erc-youtube-regex "^https?://\\(www.\\)?youtube.com/watch\\?v=\\([a-zA-Z0-9]+\\)"
-  "Regex to mach URLs to be downloaded"
+(defcustom erc-youtube-regex erc-youtube-regex-extract-videoid
+  "Regex for matching Youtube videos URLs and extracting the Video ID"
   :group 'erc-youtube
   :type '(regexp :tag "Regex"))
 
@@ -107,7 +107,8 @@ http://stackoverflow.com/users/624466/eyecatchup")
            (put-text-property pt-before (point) 'read-only t)))))))
 
 (defun erc-youtube-id (url)
-	(replace-regexp-in-string ".*youtube.com/watch\\?v=\\([a-zA-Z0-9]+\\)" "\\1" url))
+  "Extract and return the Youtube Video ID from the string URL."
+  (replace-regexp-in-string erc-youtube-regex-extract-videoid "\\1" url))
 
 (defun erc-youtube-show-info ()
   (interactive)

--- a/misc/test-matcher.el
+++ b/misc/test-matcher.el
@@ -5,7 +5,8 @@
 (defun erc-youtube/test/run-all ()
   "Should return t"
   (and
-   (erc-youtube/test/matcher-1)))
+   (erc-youtube/test/matcher-1)
+   (erc-youtube/test/matcher-2)))
 
 (defun erc-youtube/test/matcher-1 ()
   (and
@@ -30,3 +31,14 @@
     (replace-regexp-in-string
      erc-youtube-regex-extract-videoid "\\1"
      "http://www.youtube.com/v/asa_LlO6-6E&f=gdata_videos&c=ytapi-my-clientID&d=nGF83uyVrg8eD4rfEkk22mDOl3qUImVMV6ramM" nil nil))))
+
+
+(defun erc-youtube/test/matcher-2 ()
+  "Should return t"
+  (and
+   ;; expected ;; actual
+   (string= "I0kWZP9L9Kc" (erc-youtube-id "https://www.youtube.com/watch?v=I0kWZP9L9Kc&list=PL2VAYZE_4wRKKr5pJzfYD1w4tKCXARs5y&index=2"))
+   (string= "GLJbQ-mMusI" (erc-youtube-id "https://www.youtube.com/watch?v=GLJbQ-mMusI"))
+   (string= "8yEQ3ZHGUvA" (erc-youtube-id "https://www.youtube.com/watch?v=8yEQ3ZHGUvA&list=UUU9pX8hKcrx06XfOB-VQLdw"))
+   (string= "X1MBEAFLVLc" (erc-youtube-id "http://youtu.be/X1MBEAFLVLc"))
+   (string= "8yEQ3ZHGUvA" (erc-youtube-id "http://youtu.be/8yEQ3ZHGUvA?t=22m9s"))))


### PR DESCRIPTION
Closes issue #2 by extracting the YouTube Video ID directly.
