### PR TITLE
Titles with non-unibyte characters are properly encoded and inserted.

### DIFF
--- a/erc-youtube.el
+++ b/erc-youtube.el
@@ -58,6 +58,7 @@
   (search-forward "
 
 ")
+  (set-buffer-multibyte t)
   (kill-region (mark) (point))
 
 

--- a/misc/test-title.el
+++ b/misc/test-title.el
@@ -1,0 +1,33 @@
+;;; -*- emacs-lisp -*-
+;;; encoding: utf-8-unix
+
+(require 'erc-youtube)
+
+(defun erc-youtube/test/run-all ()
+  "Should return t"
+  (and
+   (erc-youtube/test/title-1)))
+
+(defun erc-youtube/test/title-1 ()
+  (and
+   ;; expected ;; actual
+   (string= "Teens Won’t Stop Setting Themselves On Fire"
+            (get-yttitle-sync "X1MBEAFLVLc"))
+   (string= "Google Chrome : Hatsune Miku (初音ミク)"
+            (get-yttitle-sync "MGt25mv4-2Q"))))
+
+
+(defun get-yttitle-sync (video-id)
+  (let* ((url (format "https://gdata.youtube.com/feeds/api/videos/%s"
+                      video-id))
+         (wkbuffer (url-retrieve-synchronously url)))
+    (with-current-buffer wkbuffer
+      (goto-char (point-min))
+      (push-mark)
+      (search-forward "\n\n")
+      (set-buffer-multibyte t) ;;
+      (kill-region (mark) (point))
+      (car (xml-node-children
+            (car (xml-get-children
+                  (car (xml-parse-region))
+                  'title)))))))


### PR DESCRIPTION
No more octal garbled text.
Includes a smart quote test case and Japanese text test case.

Signed-off-by: piyo piyo@users.sf.net
